### PR TITLE
Disable error for Dataflow Components

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = {
       "afterColon": true
     }],
     "max-nested-callbacks": [2, 2],
-    "new-cap": [2, {"newIsCap": true}],
+    "new-cap": [0],
     "new-parens": 2,
     "no-mixed-spaces-and-tabs": 2,
     "no-multiple-empty-lines": [1, {"max": 1}],


### PR DESCRIPTION
According to the new Components page on http://cycle.js.org/components.html
Section: Why name components with CapitalCase?

This PR will disable eslint errors on lines where you initialize your compontents e.g.
```
const slider = ComplexSlider()
```